### PR TITLE
Feature/targets limit

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,7 +83,8 @@
     "btnSaving": "Saving...",
     "btn": "Save target",
     "feedback": {
-      "error": "Couldn't create your target"
+      "error": "Couldn't create your target",
+      "limit": "You've riched your 10 targets limit"
     }
   },
   "deleteTarget": {

--- a/src/pages/NewTarget/NewTarget.jsx
+++ b/src/pages/NewTarget/NewTarget.jsx
@@ -58,9 +58,9 @@ const NewTarget = () => {
 
   return (
     <div className="new">
+      {console.log(error)}
       <img src={target} alt="target" className="new__target-icon" />
       <p className="form__title">{t('newTarget.title')}</p>
-
       <form className="new__form" onSubmit={handleSubmit(onSubmit)}>
         <label htmlFor="area" className="form__label new__label">
           {t('newTarget.labels.area')}
@@ -102,7 +102,13 @@ const NewTarget = () => {
           </div>
         </div>
       </form>
-      {error && <p className="new__error">{t('newTarget.feedback.error')}</p>}
+      {error && (
+        <p className="new__error">
+          {error.data.errors.targets_limit
+            ? t('newTarget.feedback.limit')
+            : t('newTarget.feedback.error')}
+        </p>
+      )}
       <img src={smiles} alt="smiles" className="new__smiles" />
     </div>
   );

--- a/src/pages/NewTarget/NewTarget.jsx
+++ b/src/pages/NewTarget/NewTarget.jsx
@@ -58,7 +58,6 @@ const NewTarget = () => {
 
   return (
     <div className="new">
-      {console.log(error)}
       <img src={target} alt="target" className="new__target-icon" />
       <p className="form__title">{t('newTarget.title')}</p>
       <form className="new__form" onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/NewTarget/NewTarget.jsx
+++ b/src/pages/NewTarget/NewTarget.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useCallback } from 'react';
 import useTranslation from 'hooks/useTranslation';
 import { useForm } from 'react-hook-form';
 import { useStore } from 'context/Store';
@@ -18,7 +19,7 @@ const NewTarget = () => {
 
   const { data: topics = [] } = useGetTopicsQuery();
 
-  const [addTarget, { isLoading, error }] = useAddTargetMutation();
+  const [addTarget, { isLoading, error, isSuccess }] = useAddTargetMutation();
 
   const schema = z.object({
     area: z.string().min(1, { message: t('newTarget.errors') }),
@@ -41,8 +42,19 @@ const NewTarget = () => {
     register,
     setValue,
     handleSubmit,
+    reset,
     formState: { errors },
   } = useForm({ resolver: zodResolver(schema) });
+
+  const resetForm = useCallback(() => {
+    if (isSuccess) {
+      reset();
+    }
+  }, [isSuccess, reset]);
+
+  useEffect(() => {
+    resetForm();
+  }, [resetForm]);
 
   return (
     <div className="new">


### PR DESCRIPTION
## Links:
https://trello.com/c/JYnqpnnE/6-2-as-a-user-i-should-only-be-able-to-create-a-maximum-of-10-targets-so-the-map-doesnt-get-too-crowded


## What & Why:
As a user I should only be able to create a maximum of 10 targets so the map doesn't get too crowded

<img width="954" alt="Screen Shot 2022-06-14 at 14 52 20" src="https://user-images.githubusercontent.com/63516257/173656989-6676994b-3672-4ca0-b69c-5f2e5f37add5.png">


## Risks, Mitigation & Rollback:
- [x] Safe to Revert *check this box if this PR can be reverted without incident*

## Acceptance criteria
- Given that I am logged in
- Given that I click the button to create the target and I filled correct data
- When there are less than 10 targets
- Then the target should be created successfully
- When there are already 10 targets
- Then the target should not be created
- Then the system should alert that there are already 10 targets